### PR TITLE
fix(SharedService): fix currency naming

### DIFF
--- a/src/shared/share.service.ts
+++ b/src/shared/share.service.ts
@@ -43,6 +43,8 @@ export class SharedService {
           .split(" ")
           .map(el => el[0].toLocaleUpperCase() + el.slice(1))
           .join(" ");
+        
+        currency.currency = curr
       });
 
       return data;


### PR DESCRIPTION
This pull request includes a small change to the `src/shared/share.service.ts` file. The change assigns the `currency` property to `curr` within the `SharedService` class.